### PR TITLE
feat: Migrate to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import setuptools
-
-setuptools.setup(
-    setup_requires=['pbr>=2.0.0'],
-    pbr=True)
+[build-system]
+requires = [
+  "pbr>=5.5.1",
+]
+build-backend = "pbr.build"


### PR DESCRIPTION
# PR Summary

## Title
Revert build system: from `pyproject.toml` (PEP 517 with PBR backend) back to `setup.py` using setuptools + PBR

## Summary
This PR replaces the PEP 517/518 build configuration with a classic `setup.py`-based build. It removes the `[build-system]` section (which declared `pbr` as the build backend) and reintroduces a `setuptools.setup(...)` invocation with `pbr=True`.

## Key Changes
- File rename: `pyproject.toml` → `setup.py`.
- Removed:
  - PEP 517 `[build-system]` configuration:
    - `requires = ["pbr>=5.5.1"]`
    - `build-backend = "pbr.build"`
- Added:
  - A minimal `setup.py` that uses:
    - `import setuptools`
    - `setuptools.setup(setup_requires=["pbr>=2.0.0"], pbr=True)`

## Rationale (implied)
- Align with environments or tooling that expect a traditional `setup.py` path.
- Potential compatibility with older `pip`/build pipelines that may not fully support PEP 517 workflows.

## Impact
- Build/Install:
  - Before: Standards-based PEP 517 builds (backend: `pbr.build`).
  - After: Legacy `setup.py` build path via setuptools.
- Dependency floor:
  - PBR minimum changes from `>=5.5.1` (in the removed configuration) to `>=2.0.0` in `setup.py`.
- Tooling:
  - Some modern build tools expecting `pyproject.toml` may no longer apply.
  - Environments not enforcing PEP 517 may find builds simpler.

## Risks
- Reduced reproducibility compared to explicit PEP 517 configuration.
- Potential inconsistencies due to the lower PBR minimum version requirement.
- CI and packaging workflows relying on `pyproject.toml` may need updates.

## Validation Recommendations
- Ensure CI builds and artifact publishing succeed with the `setup.py` flow.
- Verify wheel and sdist generation still work (e.g., `python -m build` may require adjustments).
- Confirm that PBR is correctly picked up from `setup.cfg` and entry points remain intact.
- Update contributor docs to reflect `setup.py` usage (e.g., `pip install .`).

## Suggested Changelog Entry
- Build: Reverted from PEP 517 (`pyproject.toml` with PBR backend) to classic `setup.py` using setuptools + PBR.